### PR TITLE
Fixes for enginblockauth to mysql script

### DIFF
--- a/scripts/bin/engineblockauth_to_mysql.sh
+++ b/scripts/bin/engineblockauth_to_mysql.sh
@@ -4,7 +4,7 @@
 # The filename of the ebauth message should start with ebauth-
 #
 # Some variables
-UNPROCESSED_DIR="/var/log/openconextconext/log_logins/unprocessed/"
+UNPROCESSED_DIR="/var/log/openconext/log_logins/unprocessed/"
 WORK_DIR="/var/log/openconext/log_logins/work/"
 PROCESSED_DIR="/var/log/openconext/log_logins/work/processed"
 DB_HOST="DB_HOST"

--- a/scripts/bin/engineblockauth_to_mysql.sh
+++ b/scripts/bin/engineblockauth_to_mysql.sh
@@ -6,7 +6,7 @@
 # Some variables
 UNPROCESSED_DIR="/var/log/openconext/log_logins/unprocessed/"
 WORK_DIR="/var/log/openconext/log_logins/work/"
-PROCESSED_DIR="/var/log/openconext/log_logins/work/processed"
+PROCESSED_DIR="/var/log/openconext/log_logins/work/processed/"
 DB_HOST="DB_HOST"
 DB_USER="DB_USER"
 DB_PASS="DB_PASSWORD"

--- a/scripts/bin/engineblockauth_to_mysql.sh
+++ b/scripts/bin/engineblockauth_to_mysql.sh
@@ -11,7 +11,7 @@ DB_HOST="DB_HOST"
 DB_USER="DB_USER"
 DB_PASS="DB_PASSWORD"
 DB_NAME="DB_NAME"
-JQ_BINAY="/usr/bin/jq"
+JQ_BINARY="/usr/bin/jq"
 
 if test -n "$(find $UNPROCESSED_DIR -maxdepth 1 -name 'ebauth-*' -print -quit)"
 then
@@ -22,7 +22,7 @@ fi
 
 for LOGFILE in $WORK_DIR*
 do
-cat $LOGFILE  | awk -F ]: '{ print $2 }' | sed s'/"key_id":null/"key_id":"null"/g' |$JQ_BINARY -r '.context + .extra |  [.login_stamp, .user_id, .sp_entity_id, .idp_entity_id, .key_id, .session_id, .request_id  ]  | @csv' |  sed 's/^/INSERT INTO log_logins(loginstamp,userid,spentityid,idpentityid,keyid,sessionid,requestid) VALUES (/g' | sed 's/$/) ON DUPLICATE KEY UPDATE id=id;/g' | mysql -u $DB_USER -h $DB_HOST -p$DB_PASS $DB_NAME
+cat $LOGFILE  | awk -F ]: '{ print $2 }' | sed s'/"key_id":null/"key_id":"null"/g' |$JQ_BINARY -r '.context + .extra |  [(.login_stamp[0:19] |strptime("%Y-%m-%dT%H:%M:%S") | strftime("%Y-%m-%d %H:%M:%S")), .user_id, .sp_entity_id, .idp_entity_id, .key_id, .session_id, .request_id  ]  | @csv' |  sed 's/^/INSERT INTO log_logins(loginstamp,userid,spentityid,idpentityid,keyid,sessionid,requestid) VALUES (/g' | sed 's/$/) ON DUPLICATE KEY UPDATE id=id;/g' | mysql -u $DB_USER -h $DB_HOST -p$DB_PASS $DB_NAME
 mv $LOGFILE $PROCESSED_DIR
 done
 


### PR DESCRIPTION
Minor variable name fix

Also, EBAUTH log entries are stored in 'YYYY-MM-DDTHH:MM:SS+02:00' format in syslog. Both MySQL and JQ can't handle this format time, so this truncates the Timezone from the log and passes the proper MySQL date format.

In our case, the MySQL timezone and EngineBlock timezone are both set to UTC. If you have any issues with truncating the TimeZone, please let me know.